### PR TITLE
Sub collections for Orders

### DIFF
--- a/PoSSapi/Controllers/BookingController.cs
+++ b/PoSSapi/Controllers/BookingController.cs
@@ -10,7 +10,7 @@ namespace PoSSapi.Controllers;
 [Route("[controller]")]
 public class BookingController : GenericController<Booking>
 {
-    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(ReturnObject))]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [HttpGet()]
     public ActionResult GetAll([FromQuery] string? locationId, [FromQuery] string? customerId,

--- a/PoSSapi/Controllers/CategoryController.cs
+++ b/PoSSapi/Controllers/CategoryController.cs
@@ -8,7 +8,7 @@ namespace PoSSapi.Controllers
     [Route("[controller]")]
     public class CategoryController : GenericController<Category>
     {
-        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(ReturnObject))]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [HttpGet()]
         public ActionResult GetAll([FromQuery] int itemsPerPage=10, [FromQuery] int pageNum=0)

--- a/PoSSapi/Controllers/DiscountController.cs
+++ b/PoSSapi/Controllers/DiscountController.cs
@@ -10,7 +10,7 @@ namespace PoSSapi.Controllers
     [Route("[controller]")]
     public class DiscountController : GenericController<Discount>
     {
-        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(ReturnObject))]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [HttpGet()]
         public ActionResult GetAll([FromQuery] DiscountTargetType? discountTarget, [FromQuery] string? targetId,

--- a/PoSSapi/Controllers/EmployeeController.cs
+++ b/PoSSapi/Controllers/EmployeeController.cs
@@ -13,8 +13,8 @@ namespace PoSSapi.Controllers
             public int totalItems { get; set; }
             public Shift[] itemList { get; set; }
         }
-
-        [ProducesResponseType(StatusCodes.Status200OK)]
+        
+        [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(ReturnObject))]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [HttpGet()]
         public ActionResult GetAll([FromQuery] string? username, [FromQuery] bool? isManager, [FromQuery] string? locationId, [FromQuery] int itemsPerPage=10, [FromQuery] int pageNum=0)
@@ -67,8 +67,8 @@ namespace PoSSapi.Controllers
         }
 
         /** <summary>Check out from a shift</summary>
-             * <param name="employeeId" example="">Id of the employee checking out from a shift</param>
-             */
+         * <param name="employeeId" example="">Id of the employee checking out from a shift</param>
+         */
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [HttpPost("{id}/shift/check-out")]

--- a/PoSSapi/Controllers/GenericController.cs
+++ b/PoSSapi/Controllers/GenericController.cs
@@ -33,7 +33,7 @@ namespace PoSSapi.Controllers
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [HttpGet("{id}")]
-        public ActionResult Get(string id)
+        public ActionResult<T> Get(string id)
         {
             return Ok(RandomGenerator.GenerateRandom<T>(id));
         }

--- a/PoSSapi/Controllers/PaymentController.cs
+++ b/PoSSapi/Controllers/PaymentController.cs
@@ -12,7 +12,7 @@ namespace Controllers;
 [Route("[controller]")]
 public class PaymentController : GenericController<Payment>
 {
-    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(ReturnObject))]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [HttpGet()]
     public ActionResult GetAll([FromQuery] string? orderId,

--- a/PoSSapi/Controllers/ProductController.cs
+++ b/PoSSapi/Controllers/ProductController.cs
@@ -8,7 +8,7 @@ namespace PoSSapi.Controllers;
 [Route("[controller]")]
 public class ProductController : GenericController<Product>
 {
-    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(ReturnObject))]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [HttpGet]
     public ActionResult GetAll([FromQuery] string? locationId, [FromQuery] string? categoryId, 

--- a/PoSSapi/Controllers/ProductOrderController.cs
+++ b/PoSSapi/Controllers/ProductOrderController.cs
@@ -10,7 +10,13 @@ namespace PoSSapi.Controllers;
 [Route("[controller]")]
 public class ProductOrderController : GenericController<ProductOrder>
 {
-    [ProducesResponseType(StatusCodes.Status200OK)]
+    protected class OrderProductReturnObject
+    {
+        public int totalItems { get; set; }
+        public Shift[] itemList { get; set; }
+    }
+    
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(ReturnObject))]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [HttpGet]
     public ActionResult GetAll([FromQuery] string? locationId, [FromQuery] OrderStatusState? status,
@@ -56,7 +62,7 @@ public class ProductOrderController : GenericController<ProductOrder>
      * <param name="itemsPerPage">Number of order products returned in the response</param>
      * <param name="pageNum">Number of the chunk of order products returned in the response</param>
      */
-    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(OrderProduct[]))]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(OrderProductReturnObject[]))]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [HttpGet("{id}/orderProducts")]
     public ActionResult GetOrderProducts(string id, [FromQuery] int itemsPerPage = 10, [FromQuery] int pageNum = 0)

--- a/PoSSapi/Controllers/ProductOrderController.cs
+++ b/PoSSapi/Controllers/ProductOrderController.cs
@@ -82,7 +82,7 @@ public class ProductOrderController : GenericController<ProductOrder>
         return Ok();
     }
     
-    /** <summary>Edit an order product in an existing order</summary>
+    /** <summary>Edit order products in an existing order</summary>
      * <param name="id">Id of the product order that you want to edit an order product in</param>
      * <param name="orderProducts">Order products in body to edit in the product order</param>
      */

--- a/PoSSapi/Controllers/ProductOrderController.cs
+++ b/PoSSapi/Controllers/ProductOrderController.cs
@@ -68,8 +68,7 @@ public class ProductOrderController : GenericController<ProductOrder>
      * <param name="id">Id of the product order that you want to add products to</param>
      * <param name="orderProducts">Order product list in body to add to the product order</param>
      */
-    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(OrderProduct[]))]
-    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [HttpPost("{id}/orderProducts")]
     public ActionResult PostOrderProducts(string id, [FromBody] OrderProduct[] orderProducts)
@@ -79,13 +78,12 @@ public class ProductOrderController : GenericController<ProductOrder>
     
     /** <summary>Edit an order product in an existing order</summary>
      * <param name="id">Id of the product order that you want to edit an order product in</param>
-     * <param name="orderProduct">Order product in body to edit in the product order</param>
+     * <param name="orderProducts">Order products in body to edit in the product order</param>
      */
-    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(OrderProduct[]))]
-    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [HttpPut("{id}/orderProducts")]
-    public ActionResult PutOrderProduct(string id, [FromBody] OrderProduct orderProduct)
+    public ActionResult PutOrderProducts(string id, [FromBody] OrderProduct[] orderProducts)
     {
         return Ok();
     }
@@ -94,7 +92,7 @@ public class ProductOrderController : GenericController<ProductOrder>
      * <param name="id">Id of the product order that you want to remove a product from</param>
      * <param name="orderProductId">Id of the order product to remove from the product order</param>
      */
-    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [HttpDelete("{id}/orderProducts/{orderProductId}")]
     public ActionResult DeleteOrderProduct(string id, string orderProductId)

--- a/PoSSapi/Controllers/ServiceController.cs
+++ b/PoSSapi/Controllers/ServiceController.cs
@@ -9,7 +9,7 @@ namespace PoSSapi.Controllers;
 [Route("[controller]")]
 public class ServiceController : GenericController<Service>
 {
-    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(ReturnObject))]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [HttpGet]
     public ActionResult GetAll([FromQuery] string? locationId, [FromQuery] string? categoryId,

--- a/PoSSapi/Controllers/ServiceOrderController.cs
+++ b/PoSSapi/Controllers/ServiceOrderController.cs
@@ -10,7 +10,13 @@ namespace PoSSapi.Controllers;
 [Route("[controller]")]
 public class ServiceOrderController : GenericController<Order>
 {
-    [ProducesResponseType(StatusCodes.Status200OK)]
+    protected class OrderServiceReturnObject
+    {
+        public int totalItems { get; set; }
+        public Shift[] itemList { get; set; }
+    }
+    
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(ReturnObject))]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [HttpGet]
     public ActionResult GetAll([FromQuery] string? locationId, [FromQuery] OrderStatusState? status,
@@ -56,7 +62,7 @@ public class ServiceOrderController : GenericController<Order>
      * <param name="itemsPerPage">Number of order services returned in the response</param>
      * <param name="pageNum">Number of the chunk of order services returned in the response</param>
      */
-    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(OrderService[]))]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(OrderServiceReturnObject[]))]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [HttpGet("{id}/orderServices")]
     public ActionResult GetOrderServices(string id, [FromQuery] int itemsPerPage = 10, [FromQuery] int pageNum = 0)

--- a/PoSSapi/Controllers/ServiceOrderController.cs
+++ b/PoSSapi/Controllers/ServiceOrderController.cs
@@ -82,7 +82,7 @@ public class ServiceOrderController : GenericController<Order>
         return Ok();
     }
     
-    /** <summary>Edit an order service in an existing order</summary>
+    /** <summary>Edit order services in an existing order</summary>
      * <param name="id">Id of the service order that you want to edit an order service in</param>
      * <param name="orderServices">Order services in body to edit in the service order</param>
      */

--- a/PoSSapi/Controllers/ServiceOrderController.cs
+++ b/PoSSapi/Controllers/ServiceOrderController.cs
@@ -68,8 +68,7 @@ public class ServiceOrderController : GenericController<Order>
      * <param name="id">Id of the service order that you want to add services to</param>
      * <param name="orderServices">Order service list in body to add to the service order</param>
      */
-    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(OrderService[]))]
-    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [HttpPost("{id}/orderServices")]
     public ActionResult PostOrderServices(string id, [FromBody] OrderService[] orderServices)
@@ -79,13 +78,12 @@ public class ServiceOrderController : GenericController<Order>
     
     /** <summary>Edit an order service in an existing order</summary>
      * <param name="id">Id of the service order that you want to edit an order service in</param>
-     * <param name="orderService">Order service in body to edit in the service order</param>
+     * <param name="orderServices">Order services in body to edit in the service order</param>
      */
-    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(OrderService[]))]
-    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [HttpPut("{id}/orderServices")]
-    public ActionResult PutOrderService(string id, [FromBody] OrderService orderService)
+    public ActionResult PutOrderServices(string id, [FromBody] OrderService[] orderServices)
     {
         return Ok();
     }
@@ -94,7 +92,7 @@ public class ServiceOrderController : GenericController<Order>
      * <param name="id">Id of the service order that you want to remove a service from</param>
      * <param name="orderServiceId">Id of the order service to remove from the service order</param>
      */
-    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [HttpDelete("{id}/orderServices/{orderServiceId}")]
     public ActionResult DeleteOrderService(string id, string orderServiceId)

--- a/PoSSapi/Controllers/ServiceOrderController.cs
+++ b/PoSSapi/Controllers/ServiceOrderController.cs
@@ -8,7 +8,7 @@ namespace PoSSapi.Controllers;
 
 [ApiController]
 [Route("[controller]")]
-public class orderServiceController : GenericController<Order>
+public class ServiceOrderController : GenericController<Order>
 {
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]

--- a/PoSSapi/Controllers/ServiceOrderController.cs
+++ b/PoSSapi/Controllers/ServiceOrderController.cs
@@ -8,7 +8,7 @@ namespace PoSSapi.Controllers;
 
 [ApiController]
 [Route("[controller]")]
-public class ServiceOrderController : GenericController<Order>
+public class orderServiceController : GenericController<Order>
 {
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]

--- a/PoSSapi/Controllers/ShiftController.cs
+++ b/PoSSapi/Controllers/ShiftController.cs
@@ -1,0 +1,66 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Classes;
+using PoSSapi.Tools;
+using System.ComponentModel.DataAnnotations;
+using PoSSapi.Controllers;
+
+namespace Controllers;
+
+[ApiController]
+[Route("[controller]")]
+public class ShiftController : GenericController<Shift>
+{
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(ReturnObject))]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [HttpGet()]
+    public ActionResult GetAll([FromQuery] string? employeeId, [FromQuery] int itemsPerPage = 10, [FromQuery] int pageNum = 0)
+    {
+        if (itemsPerPage <= 0)
+        {
+            return BadRequest("itemsPerPage must be greater than 0");
+        }
+        if (pageNum < 0)
+        {
+            return BadRequest("pageNum must be 0 or greater");
+        }
+
+        int totalItems = 20;
+        int itemsToDisplay = ControllerTools.calculateItemsToDisplay(itemsPerPage, pageNum, totalItems);
+
+        var objectList = new Shift[itemsToDisplay];
+        for (int i = 0; i < itemsToDisplay; ++i)
+        {
+            objectList[i] = RandomGenerator.GenerateRandom<Shift>();
+
+            if (employeeId != null)
+            {
+                objectList[i].EmployeeId = employeeId;
+            }
+        }
+
+        ReturnObject returnObject = new ReturnObject { totalItems = totalItems, itemList = objectList };
+        return Ok(returnObject);
+    }
+
+    /** <summary>Check in for a shift</summary>
+     * <param name="employeeId" example="">Id of the employee checking in for a shift</param>
+     */
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [HttpPost("{id}/check-in")]
+    public ActionResult CheckInShift(string employeeId)
+    {
+        return Ok();
+    }
+
+    /** <summary>Check out from a shift</summary>
+     * <param name="employeeId" example="">Id of the employee checking out from a shift</param>
+     */
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [HttpPost("{id}/check-out")]
+    public ActionResult CheckOutShift(string employeeId)
+    {
+        return Ok();
+    }
+}


### PR DESCRIPTION
I created sub-collections for these user stories:

- 3.1. Orders
- 3.4 Handle products
- 3.7 Handle Services

I noticed that if there is no explicit annotation like:
```
[ProducesResponseType(StatusCodes.Status200OK, Type = typeof(OrderService[]))]
```

Then the response type is some kind of a default response type. So maybe we should add types?

Also, we don't have a response type in case of errors:
```
[ProducesResponseType(StatusCodes.Status400BadRequest)]
```
And  default response type is also generated in Swagger. But I don't think we should try to define it? Too much work.